### PR TITLE
Fix for new rails erb signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ flay-actionpack
 ==============
 
 Flay plugin for rails erb templates.
-Tested with Rails 3.x and 4.0
+Tested with Rails 7.x
 
 Installation
 ------------

--- a/flay-actionpack.gemspec
+++ b/flay-actionpack.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "flay", ">= 1.2", "< 3"
-  spec.add_development_dependency "actionpack", ">= 3", "< 5"
-  spec.add_development_dependency "bundler", ">= 2.2.10"
+  spec.add_development_dependency "actionpack", ">= 7"
   spec.add_development_dependency "rake"
 end

--- a/lib/flay_actionpack.rb
+++ b/lib/flay_actionpack.rb
@@ -3,7 +3,7 @@ require 'action_view'
 
 class Flay
   
-  @@plugins |= %w(erb)
+  @@plugins ||= %w(erb)
 
   ##
   # Process erb template and parse the result. Returns the sexp of the parsed

--- a/lib/flay_actionpack.rb
+++ b/lib/flay_actionpack.rb
@@ -12,7 +12,7 @@ class Flay
   def process_erb file
     erb = File.read file
     src = Struct.new(:source, :mime_type, :type).new(erb, 'text/html', 'text/html')
-    ruby = ActionView::Template::Handlers::ERB.call src
+    ruby = ActionView::Template::Handlers::ERB.call src, erb
     begin
       RubyParser.new.process(ruby, file)
     rescue => e

--- a/test/test_flay_actionpack.rb
+++ b/test/test_flay_actionpack.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require 'flay'
 require 'action_view'
+require 'flay_actionpack'
 
 class TestFlayActionpack < MiniTest::Unit::TestCase
   def test_actionpack_erb


### PR DESCRIPTION
This PR fixes #2 .

The original code caused all ERB files in a Rails 7.0 project to be skipped from duplication checking due to this difference.

Will leave it up to you @UncleGene to change the version and release the gem.